### PR TITLE
Allow clicking on open file image

### DIFF
--- a/style/main_jianyi.css
+++ b/style/main_jianyi.css
@@ -98,6 +98,11 @@ h3{
     z-index:3;
     cursor:pointer;
 }
+
+#open1 img {
+    pointer-events: none;
+}
+
 #infoMsg{
     position:absolute;
     top:170px;


### PR DESCRIPTION
Without this change, you may only open a file by clicking "打开图片". This change allows you to click on the folder image. This is more consistent with the other action buttons, which allow clicking on the image.